### PR TITLE
Update notebook CSS from 4.3.0 to 5.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ package_data = {
 }
 
 
-notebook_css_version = '4.3.0'
+notebook_css_version = '5.1.0'
 css_url = "https://cdn.jupyter.org/notebook/%s/style/style.min.css" % notebook_css_version
 
 class FetchCSS(Command):


### PR DESCRIPTION
A key benefit if the better pandas dataframe styling.  
Generally I understand from @takluyver that there is no reason to use and older version. See issue #679.